### PR TITLE
feat: change alliances based on driver station or manually

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -23,18 +23,19 @@ public class RobotContainer {
 
   // Aqui iniciamos o swerve
   private SwerveSubsystem swerve = new SwerveSubsystem(new File(Filesystem.getDeployDirectory(), "swerve"));
-  
-  // Controle de Xbox, troque para o qual sua equipe estará utilizando
-  public XboxController controleXbox = new XboxController(Controle.xboxControle);
+
+  private DriverController driverController = DriverController.getInstance();
 
   public RobotContainer() {
 
     // Definimos o comando padrão como a tração
     swerve.setDefaultCommand(swerve.driveCommand(
-      () -> MathUtil.applyDeadband(controleXbox.getLeftY(), Constants.Controle.DEADBAND),
-      () -> MathUtil.applyDeadband(controleXbox.getLeftX(), Constants.Controle.DEADBAND),
-      () ->  MathUtil.applyDeadband(controleXbox.getRightX(), Constants.Controle.DEADBAND))
+      driverController.getXtranslation(),
+      driverController.getYtranslation(),
+      driverController.getRotation())
     );
+
+    driverController.leftBumper().onTrue(new InstantCommand(() -> driverController.changeAlliances()));
 
     NamedCommands.registerCommand("Intake", new PrintCommand("Intake"));
 

--- a/src/main/java/frc/robot/joysticks/DriverController.java
+++ b/src/main/java/frc/robot/joysticks/DriverController.java
@@ -1,0 +1,92 @@
+package frc.robot.joysticks;
+
+import edu.wpi.first.math.MathUtil;
+import edu.wpi.first.wpilibj.DriverStation;
+import edu.wpi.first.wpilibj.DriverStation.Alliance;
+import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
+import edu.wpi.first.wpilibj2.command.button.Trigger;
+import frc.robot.Constants.Controle;
+
+public class DriverController {
+
+  private static DriverController mInstance = null;
+
+  public static DriverController getInstance() {
+    if (mInstance == null) {
+      mInstance = new DriverController();
+    }
+
+    return mInstance;
+  }
+
+  final CommandXboxController driverController;
+
+  private double allianceInputDirectionCorrection = 1;
+
+  private DriverController() {
+    driverController = new CommandXboxController(Controle.xboxControle);
+  }
+
+  public void changeAlliances() {
+    allianceInputDirectionCorrection = allianceInputDirectionCorrection * -1;
+  }
+
+  public double getXtranslation() {
+    if (turboActivate().getAsBoolean()) {
+      return -MathUtil.applyDeadband(performAllianceInputDirectionCorrection(driverController.getLeftX()),
+          Constants.Controle.DEADBAND) * allianceInputDirectionCorrection;
+    }
+    return -MathUtil.applyDeadband(performAllianceInputDirectionCorrection(driverController.getLeftX()),
+        Constants.Controle.DEADBAND) * 0.6 * allianceInputDirectionCorrection;
+  }
+
+  public double getYtranslation() {
+    if (turboActivate().getAsBoolean()) {
+      return -MathUtil.applyDeadband(performAllianceInputDirectionCorrection(driverController.getLeftY()),
+          Constants.Controle.DEADBAND) * allianceInputDirectionCorrection;
+    }
+    return -MathUtil.applyDeadband(performAllianceInputDirectionCorrection(driverController.getLeftY()),
+        Constants.Controle.DEADBAND) * 0.6 * allianceInputDirectionCorrection;
+  }
+
+  public double getRotation() {
+    return MathUtil.applyDeadband(driverController.getRightX(), Constants.Controle.DEADBAND);
+  }
+  
+  public Trigger turboActivate() {
+    return driverController.rightTrigger(0.2);
+  }
+
+  public Trigger a() {
+    return driverController.a();
+  }
+
+  public Trigger y() {
+    return driverController.y();
+  }
+
+  public Trigger x() {
+    return driverController.x();
+  }
+
+  public Trigger b() {
+    return driverController.b();
+  }
+
+  public Trigger leftBumper() {
+    return driverController.leftBumper();
+  }
+
+  public Trigger rightBumper() {
+    return driverController.rightBumper();
+  }
+
+  private double performAllianceInputDirectionCorrection(Double value) {
+    Alliance alliance = DriverStation.getAlliance().isPresent() ? DriverStation.getAlliance().get()
+        : DriverStation.Alliance.Red;
+    if (alliance == Alliance.Red) {
+      return -value;
+    }
+    return value;
+  }
+}


### PR DESCRIPTION
Fiz algumas mudanças.
Em teoria agora ele deveria trocar de aliança dependendo da cor da driver station que estiverem e arrumar esse problema.
Também deixei o L1 como um botão que inverte os controles, daí se der problema vcs conseguem inverter eles.
Eu apliquei o boost que usamos na under, com isso o robô anda mais devagar sempre pra ficar mais fácil de controlar e quando seguram o R2 ele vai na velocidade máxima, achamos que fica mais fácil de dirigir assim